### PR TITLE
Update telegram domain to t.me

### DIFF
--- a/app/components/SocialLinks.vue
+++ b/app/components/SocialLinks.vue
@@ -1,7 +1,7 @@
 <template>
   <ul class="social-links d-flex align-items-center rest">
     <li>
-      <a href="https://telegram.me/denisoed" target="_blank" aria-label="Telegram link">
+      <a href="https://t.me/denisoed" target="_blank" aria-label="Telegram link">
         <i class="fab fa-telegram"></i>
       </a>
     </li>


### PR DESCRIPTION
Update Telegram link domain from `telegram.me` to `t.me` for consistency and brevity.

---
<a href="https://cursor.com/background-agent?bcId=bc-22bb14ce-02f3-4aa4-a2de-6370d9117a2e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-22bb14ce-02f3-4aa4-a2de-6370d9117a2e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

